### PR TITLE
Add meson support

### DIFF
--- a/.github/workflows/test_gfortran_msys_windows.yml
+++ b/.github/workflows/test_gfortran_msys_windows.yml
@@ -23,6 +23,8 @@ jobs:
           git
           wget
           mingw-w64-x86_64-gcc-fortran
+          mingw-w64-x86_64-meson
+          mingw-w64-x86_64-ninja
 
     - name: Install fpm
       shell: msys2 {0}
@@ -47,6 +49,12 @@ jobs:
       env:
          FC: gfortran
          TZ: UTC+04:00
+
+    - name: Build with meson
+      run: |
+        meson --version
+        meson setup build -Dbuildtype=debug
+        meson compile -C build
 
     - name: cleanup 
       run: dir

--- a/.github/workflows/test_gfortran_msys_windows.yml
+++ b/.github/workflows/test_gfortran_msys_windows.yml
@@ -51,6 +51,7 @@ jobs:
          TZ: UTC+04:00
 
     - name: Build with meson
+      shell: msys2 {0}
       run: |
         meson --version
         meson setup build -Dbuildtype=debug

--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ These demo programs provide templates for the most common usage:
         [dependencies]
         M_CLI2        = { git = "https://github.com/urbanjost/M_CLI2.git" }
 ```
+
+## Supports Meson
+   Alternatively, meson(1) users may download the github repository and build it with
+   meson ( as described at [Meson Build System](https://mesonbuild.com/) )
+```bash
+        git clone https://github.com/urbanjost/M_CLI2.git
+        cd M_CLI2
+        meson setup _build
+        meson test -C _build  # build and test the module
+        meson install -C _build --destdir <DIR> # install the module (in the <DIR> location)
+```
+   or just list it as a [subproject dependency](https://mesonbuild.com/Subprojects.html) in your meson.build project file.
+```meson
+        M_CLI2_dep = subproject('M_CLI2').get_variable('M_CLI2_dep')
+```
+
 ## Functional Specification
 **This is how the interface works --**
 

--- a/meson.build
+++ b/meson.build
@@ -24,3 +24,12 @@ M_CLI2_dep = declare_dependency(
     link_with : M_CLI2_lib,
     include_directories : M_CLI2_inc,
 )
+
+test(
+    'runTests',
+    executable(
+        'runTests',
+        'test/test_suite_M_CLI2.f90',
+        dependencies : M_CLI2_dep,
+    ),
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project(
+    'M_CLI2',
+    'fortran',
+    version : '1.0.0',
+    license : 'UNLICENSE',
+    default_options : [
+        'buildtype=debugoptimized',
+    ]
+)
+
+M_CLI2_src = files(
+    'src/M_CLI2.F90'
+)
+
+M_CLI2_lib = library(
+    meson.project_name(),
+    sources : M_CLI2_src,
+    version : meson.project_version(),
+    install : true,
+)
+
+M_CLI2_inc = M_CLI2_lib.private_dir_include()
+M_CLI2_dep = declare_dependency(
+    link_with : M_CLI2_lib,
+    include_directories : M_CLI2_inc,
+)

--- a/src/M_CLI2.F90
+++ b/src/M_CLI2.F90
@@ -3074,7 +3074,7 @@ integer                              :: half,sz,i
    if(allocated(xarray))deallocate(xarray)
    allocate(xarray(half))
    do i=1,sz,2
-      xarray((i+1)/2)=cmplx( darray(i),darray(i+1) )
+      xarray((i+1)/2)=cmplx( darray(i),darray(i+1),kind=sp )
    enddo
    !x!================================================================================================
 


### PR DESCRIPTION
### Description

In terms of experience, fpm, CMake, Meson and Make are all easy to use in Fortran projects.

Meson is simpler to use than CMake. Configuring M_CLI2 as a Meson package makes it easy to use Meson to build dynamic, static link libraries, or for Meson subprojects packages.

```sh
meson setup _build
meson compile -C _build
meson test -C _build
```

PS. Do I need to add documentation to the README for the meson build? Or just add `meson.build` file.

- [x] Add meson build support;
- [x] Add meson test;
- [x] Add meson build CI;
- [x] Fix a warning;
- [x] Update README for meson build.