### PR TITLE
Install m_cli2.mod in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,8 @@ project(
     license : 'UNLICENSE',
     default_options : [
         'buildtype=debugoptimized',
+        'fortran_std=f2008',
+        'default_library=both',
     ]
 )
 
@@ -32,4 +34,40 @@ test(
         'test/test_suite_M_CLI2.f90',
         dependencies : M_CLI2_dep,
     ),
+)
+
+M_CLI2_lic = files(
+    'LICENSE',
+)
+install_data(
+    M_CLI2_lic,
+    install_dir : join_paths(get_option('prefix'), 'share', 'licenses', meson.project_name()),
+)
+
+if host_machine.system() == 'windows'
+    symbols_file = 'lib'+meson.project_name()+'-'+meson.project_version().split('.')[0]+'.dll.symbols'
+    obj_file = 'src_M_CLI2.F90.obj'
+else
+    symbols_file = 'lib'+meson.project_name()+'.so.'+meson.project_version()+'.symbols'
+    obj_file = 'src_M_CLI2.F90.o'
+endif
+install_subdir(M_CLI2_lib.path()+'.p',
+    install_dir: 'include'/meson.project_name(),
+    strip_directory: true,
+    exclude_files: [
+        'depscan.dd',
+        meson.project_name()+'-deps.json',
+        meson.project_name()+'.dat',
+        symbols_file,
+        obj_file,
+    ]
+)
+
+pkg = import('pkgconfig')
+pkg.generate(
+    name : meson.project_name(),
+    description : 'Fortran commandline-interface using a simple prototype command',
+    version : meson.project_version(),
+    libraries : M_CLI2_lib,
+    subdirs : meson.project_name(),
 )


### PR DESCRIPTION
Update the `meson.build` rule and install `m_cli2.mod`. Fix #17 .
(Locally tested, `ifort` and `gfortran` are successful under Linux, and `Windows-MSYS2-gfortran` is successful.)

In addition, added the standard `fortran_std=f2008` limit, `LICENSE` and `M_CLI2.pc`(pkgconfig) file installation.